### PR TITLE
Centralize data paths

### DIFF
--- a/src/busavsjo_exportera_betyg_excel.py
+++ b/src/busavsjo_exportera_betyg_excel.py
@@ -1,5 +1,6 @@
 import openpyxl
 import os
+from config_paths import OUTPUT_DIR
 
 # Definiera rubrikerna
 headers = [
@@ -9,8 +10,8 @@ headers = [
     "Sv", "Sva", "Tn", "Tk", "Ovr"
 ]
 
-# Sätt sökvägar
-DATA_MAPP = os.path.join(os.path.dirname(__file__), "..", "data", "output")
+# Sätt sökvägar via konfigurerade mappar
+DATA_MAPP = OUTPUT_DIR
 TXT_FIL = os.path.join(DATA_MAPP, "betyg.txt")
 EXCEL_FIL = os.path.join(DATA_MAPP, "betyg.xlsx")
 

--- a/src/busavsjo_korrelation_betyg_franvaro.py
+++ b/src/busavsjo_korrelation_betyg_franvaro.py
@@ -3,9 +3,10 @@ import hashlib
 import os
 from openpyxl.styles import PatternFill
 from openpyxl import load_workbook
+from config_paths import OUTPUT_DIR
 
 # === INSTÄLLNINGAR ===
-DATA_MAPP = os.path.join(os.path.dirname(__file__), "..", "data", "output")
+DATA_MAPP = OUTPUT_DIR
 FIL_FRANVARO = os.path.join(DATA_MAPP, "franvaro_rensad_kategoriserad.xlsx")
 FRANVARO_FLIK = "Rensad data"
 BETYG_FIL = os.path.join(DATA_MAPP, "betyg.xlsx")

--- a/src/busavsjo_samla_franvaro.py
+++ b/src/busavsjo_samla_franvaro.py
@@ -1,6 +1,7 @@
 import os
 import xlrd
 import xlwt
+from config_paths import RAW_FRANVARO_DIR, OUTPUT_DIR
 
 
 def busavsjo_samla_franvarorapporter():
@@ -8,9 +9,8 @@ def busavsjo_samla_franvarorapporter():
     Slår ihop alla .xls-filer i ``data/raw/franvaro`` till en fil (``data/output/franvaro.xls``),
     behåller bara rubriken från första filen och hoppar över de fyra första raderna i resten.
     """
-    rotmapp = os.path.dirname(os.path.dirname(__file__))
-    indata_mapp = os.path.join(rotmapp, "data", "raw", "franvaro")
-    output_fil = os.path.join(rotmapp, "data", "output", "franvaro.xls")
+    indata_mapp = RAW_FRANVARO_DIR
+    output_fil = os.path.join(OUTPUT_DIR, "franvaro.xls")
 
     wb_out = xlwt.Workbook()
     ws_out = wb_out.add_sheet("Data")

--- a/src/config_paths.py
+++ b/src/config_paths.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+RAW_DIR = BASE_DIR / "data" / "raw"
+RAW_BETYG_DIR = RAW_DIR / "betyg"
+RAW_FRANVARO_DIR = RAW_DIR / "franvaro"
+OUTPUT_DIR = BASE_DIR / "data" / "output"


### PR DESCRIPTION
## Summary
- add `config_paths` module for raw and output directories
- use new paths in grade export, attendance merge, and correlation scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a8f7f497483288940beee39a87a3e