### PR TITLE
Refactor file path handling

### DIFF
--- a/src/busavsjo_exportera_betyg_excel.py
+++ b/src/busavsjo_exportera_betyg_excel.py
@@ -1,5 +1,4 @@
 import openpyxl
-import os
 from config_paths import OUTPUT_DIR
 
 # Definiera rubrikerna
@@ -12,8 +11,8 @@ headers = [
 
 # Sätt sökvägar via konfigurerade mappar
 DATA_MAPP = OUTPUT_DIR
-TXT_FIL = os.path.join(DATA_MAPP, "betyg.txt")
-EXCEL_FIL = os.path.join(DATA_MAPP, "betyg.xlsx")
+TXT_FIL = DATA_MAPP / "betyg.txt"
+EXCEL_FIL = DATA_MAPP / "betyg.xlsx"
 
 # Funktion för att formattera personnummer till YYMMDD-XXXX utan apostrof
 
@@ -30,11 +29,11 @@ def exportera_betyg_excel():
 
     # Försök att läsa in filen som UTF-8
     try:
-        with open(TXT_FIL, 'r', encoding='utf-8') as f:
+        with TXT_FIL.open('r', encoding='utf-8') as f:
             lines = f.readlines()
     except UnicodeDecodeError:
         # Om det misslyckas, försök med cp1252 och ersätt icke-dekodbara tecken
-        with open(TXT_FIL, 'r', encoding='cp1252', errors='replace') as f:
+        with TXT_FIL.open('r', encoding='cp1252', errors='replace') as f:
             lines = f.readlines()
 
     # Skapa en ny arbetsbok

--- a/src/busavsjo_korrelation_betyg_franvaro.py
+++ b/src/busavsjo_korrelation_betyg_franvaro.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import hashlib
-import os
 import json
 from openpyxl.styles import PatternFill
 from openpyxl import load_workbook
@@ -8,12 +7,12 @@ from config_paths import OUTPUT_DIR
 
 # === INSTÄLLNINGAR ===
 DATA_MAPP = OUTPUT_DIR
-FIL_FRANVARO = os.path.join(DATA_MAPP, "franvaro_rensad_kategoriserad.xlsx")
+FIL_FRANVARO = DATA_MAPP / "franvaro_rensad_kategoriserad.xlsx"
 FRANVARO_FLIK = "Rensad data"
-BETYG_FIL = os.path.join(DATA_MAPP, "betyg.xlsx")
-OUTPUT_FIL = os.path.join(DATA_MAPP, "busavsjo_korrelation_input.xlsx")
-RESULTAT_FIL = os.path.join(DATA_MAPP, "busavsjo_korrelation_resultat.xlsx")
-JSON_MAPP = os.path.join(DATA_MAPP, "json")
+BETYG_FIL = DATA_MAPP / "betyg.xlsx"
+OUTPUT_FIL = DATA_MAPP / "busavsjo_korrelation_input.xlsx"
+RESULTAT_FIL = DATA_MAPP / "busavsjo_korrelation_resultat.xlsx"
+JSON_MAPP = DATA_MAPP / "json"
 
 IGNORERA_KOLUMNER = {
     "System", "Datum", "Version", "Skolenhetskod",
@@ -145,8 +144,8 @@ if korrelationer:
     wb.save(RESULTAT_FIL)
     print(f"✔️ Färgkodad Excel-fil sparad till '{RESULTAT_FIL}'")
 
- # === STEG 7 ===
-os.makedirs(JSON_MAPP, exist_ok=True)
+# === STEG 7 ===
+JSON_MAPP.mkdir(parents=True, exist_ok=True)
 
 # Tvinga bort NaN och avrunda giltiga värden
 ogiltig_df_clean = ogiltig_df.copy()
@@ -158,10 +157,10 @@ total_df_clean["Korrelation"] = total_df_clean["Korrelation"].apply(lambda x: ro
 ogiltig_df_clean = ogiltig_df_clean.where(pd.notna(ogiltig_df_clean), None)
 total_df_clean = total_df_clean.where(pd.notna(total_df_clean), None)
 
-with open(os.path.join(JSON_MAPP, "ogiltig_franvaro.json"), "w", encoding="utf-8") as f:
+with (JSON_MAPP / "ogiltig_franvaro.json").open("w", encoding="utf-8") as f:
     json.dump(ogiltig_df_clean.to_dict(orient="records"), f, indent=2, ensure_ascii=False)
 
-with open(os.path.join(JSON_MAPP, "total_franvaro.json"), "w", encoding="utf-8") as f:
+with (JSON_MAPP / "total_franvaro.json").open("w", encoding="utf-8") as f:
     json.dump(total_df_clean.to_dict(orient="records"), f, indent=2, ensure_ascii=False)
 
 print(f"✔️ JSON-data sparad i '{JSON_MAPP}'")

--- a/src/busavsjo_rensa_franvaro_excel.py
+++ b/src/busavsjo_rensa_franvaro_excel.py
@@ -3,11 +3,10 @@ from openpyxl import Workbook
 from openpyxl.styles import PatternFill, Alignment, Font, Border, Side
 from openpyxl.utils.dataframe import dataframe_to_rows
 import re
-import os
-
-DATA_MAPP = os.path.join(os.path.dirname(__file__), "..", "data", "output")
-FIL_IN = os.path.join(DATA_MAPP, "franvaro.xls")
-FIL_UT = os.path.join(DATA_MAPP, "franvaro_rensad_kategoriserad.xlsx")
+from config_paths import OUTPUT_DIR
+DATA_MAPP = OUTPUT_DIR
+FIL_IN = DATA_MAPP / "franvaro.xls"
+FIL_UT = DATA_MAPP / "franvaro_rensad_kategoriserad.xlsx"
 
 def rensa_franvaro_excel():
     """Rensar och summerar frånvarodata från ``franvaro.xls``."""

--- a/src/busavsjo_samla_betygstxt.py
+++ b/src/busavsjo_samla_betygstxt.py
@@ -1,23 +1,19 @@
-import os
+from config_paths import RAW_BETYG_DIR, OUTPUT_DIR
 
 def busavsjo_samla_txtfiler():
     """Läser in alla .txt-filer i ``data/raw/betyg`` och
     sparar ihop dem till ``data/output/betyg.txt``"""
-    rotmapp = os.path.dirname(os.path.dirname(__file__))
-    indata_mapp = os.path.join(rotmapp, "data", "raw", "betyg")
-    utdata_fil = os.path.join(rotmapp, "data", "output", "betyg.txt")
+    indata_mapp = RAW_BETYG_DIR
+    utdata_fil = OUTPUT_DIR / "betyg.txt"
     med_antal = 0
 
-    with open(utdata_fil, "w", encoding="utf-8") as utfil:
-        for filnamn in sorted(os.listdir(indata_mapp)):
-            if filnamn.endswith(".txt") and filnamn != "betyg.txt":
-                filväg = os.path.join(indata_mapp, filnamn)
+    with utdata_fil.open("w", encoding="utf-8") as utfil:
+        for filväg in sorted(indata_mapp.iterdir()):
+            if filväg.suffix == ".txt" and filväg.name != "betyg.txt":
                 try:
-                    with open(filväg, "r", encoding="utf-8") as infil:
-                        innehåll = infil.read()
+                    innehåll = filväg.read_text(encoding="utf-8")
                 except UnicodeDecodeError:
-                    with open(filväg, "r", encoding="latin-1") as infil:
-                        innehåll = infil.read()
+                    innehåll = filväg.read_text(encoding="latin-1")
 
                 utfil.write(innehåll.strip() + "\n\n")
                 med_antal += 1

--- a/src/busavsjo_samla_franvaro.py
+++ b/src/busavsjo_samla_franvaro.py
@@ -1,4 +1,3 @@
-import os
 import xlrd
 import xlwt
 from config_paths import RAW_FRANVARO_DIR, OUTPUT_DIR
@@ -10,7 +9,7 @@ def busavsjo_samla_franvarorapporter():
     behåller bara rubriken från första filen och hoppar över de fyra första raderna i resten.
     """
     indata_mapp = RAW_FRANVARO_DIR
-    output_fil = os.path.join(OUTPUT_DIR, "franvaro.xls")
+    output_fil = OUTPUT_DIR / "franvaro.xls"
 
     wb_out = xlwt.Workbook()
     ws_out = wb_out.add_sheet("Data")
@@ -18,18 +17,17 @@ def busavsjo_samla_franvarorapporter():
     rad_index = 0
     antal_filer = 0
 
-    for filnamn in sorted(os.listdir(indata_mapp)):
-        if filnamn.endswith(".xls") and filnamn != "franvaro.xls":
-            filvag = os.path.join(indata_mapp, filnamn)
+    for filväg in sorted(indata_mapp.iterdir()):
+        if filväg.suffix == ".xls" and filväg.name != "franvaro.xls":
             try:
-                wb_in = xlrd.open_workbook(filvag)
+                wb_in = xlrd.open_workbook(filväg)
                 sheet = wb_in.sheet_by_index(0)
 
                 start_row = 0 if antal_filer == 0 else 4  # behåll rubrik bara från första filen
 
                 # Infoga filnamn som kommentarrad (om inte första filen)
                 if antal_filer > 0:
-                    ws_out.write(rad_index, 0, f"Från fil: {filnamn}")
+                    ws_out.write(rad_index, 0, f"Från fil: {filväg.name}")
                     rad_index += 1
 
                 for row_idx in range(start_row, sheet.nrows):
@@ -40,7 +38,7 @@ def busavsjo_samla_franvarorapporter():
                 antal_filer += 1
 
             except Exception as e:
-                print(f"⚠️ Kunde inte läsa {filnamn}: {e}")
+                print(f"⚠️ Kunde inte läsa {filväg.name}: {e}")
 
     wb_out.save(output_fil)
     print(f"✔️ Skapade '{output_fil}' med {antal_filer} rapporter")


### PR DESCRIPTION
## Summary
- use `RAW_BETYG_DIR` and `OUTPUT_DIR` paths in `busavsjo_samla_betygstxt`
- refactor manual path logic in the other modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688b1cd276788328a0f7e45cda355b1f