### PR TITLE
Add frontend filter for correlation tables

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,22 +60,50 @@
       margin-top: 0;
       color: #0d47a1;
     }
+    .filter {
+      margin-bottom: 20px;
+    }
+    .filter label {
+      margin-right: 10px;
+      font-weight: 600;
+    }
+    .filter select {
+      padding: 8px 12px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+    }
+    .tabell-section {
+      margin-bottom: 40px;
+    }
   </style>
 </head>
 <body>
   <div class="container">
     <h1>Korrelationer mellan betyg och frånvaro</h1>
 
-    <div class="dashboard" id="dashboard"></div>
+    <div class="filter">
+      <label for="filter">Välj korrelation:</label>
+      <select id="filter">
+        <option value="alla">Visa alla</option>
+        <option value="ogiltig">Ogiltig frånvaro</option>
+        <option value="total">Total frånvaro</option>
+        <option value="merit">Meritvärde</option>
+      </select>
+    </div>
 
+    <div class="dashboard" id="dashboard"></div>
+    <div id="ogiltig-section" class="tabell-section">
     <h2>Ogiltig frånvaro</h2>
     <table id="ogiltig"></table>
-
+    </div>
+    <div id="total-section" class="tabell-section">
     <h2>Total frånvaro</h2>
     <table id="total"></table>
-
+    </div>
+    <div id="merit-section" class="tabell-section">
     <h2>Meritvärde</h2>
     <table id="merit"></table>
+    </div>
   </div>
 
   <script>
@@ -126,6 +154,20 @@
       card.innerHTML = `<h3>${titel}</h3><p>${värde}</p>`;
       document.getElementById("dashboard").appendChild(card);
     }
+    function visaTabell(varde) {
+      ["ogiltig","total","merit"].forEach(id => {
+        const sektion = document.getElementById(`${id}-section`);
+        if (varde === "alla" || varde === id) {
+          sektion.style.display = "";
+        } else {
+          sektion.style.display = "none";
+        }
+      });
+    }
+
+    document.getElementById("filter").addEventListener("change", e => visaTabell(e.target.value));
+    visaTabell("alla");
+
 
     fetch("json/ogiltig_franvaro.json")
       .then(r => r.json())


### PR DESCRIPTION
## Summary
- add UI filter to toggle correlation tables
- style dropdown and sections
- hide/show sections via JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b9e0c7b1c8328857dfc6544d40b26