### PR TITLE
Add school year awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ Projektet använder en **raw/output**-struktur under `data/`:
 - `data/raw/franvaro/` – här läggs frånvarofiler (`.xls`) från Vklass.
 - `data/output/` – hit skrivs samtliga genererade filer.
 
+### Läsår och mappar
+
+I `src/config_paths.py` finns konstanten `LASAR` som anger vilket läsår som
+analyseras (exempelvis `"2024/2025"`). Alla rå- och outputfiler sparas i
+undermappar med detta namn, t.ex. `data/raw/betyg/<läsår>` och
+`data/output/<läsår>`. På så vis kan flera års data hanteras utan konflikt.
+
+De JSON-filer som genereras för webbgränssnittet hamnar i
+`data/output/<läsår>/json/`. Kopiera dem vid behov till motsvarande mapp under
+`public/json/<läsår>` för att exponera dem via webbplatsen.
+
 Kör hela flödet med:
 
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -89,6 +89,10 @@
         <option value="total">Total frånvaro</option>
         <option value="merit">Meritvärde</option>
       </select>
+      <label for="lasar-select" style="margin-left:20px;">Läsår:</label>
+      <select id="lasar-select">
+        <option value="alla">Alla</option>
+      </select>
     </div>
 
     <div class="dashboard" id="dashboard"></div>
@@ -107,6 +111,12 @@
   </div>
 
   <script>
+    const LASAR = "2024/2025";
+    let dataOgiltig = [];
+    let dataTotal = [];
+    let dataMerit = [];
+    const lasarSet = new Set();
+
     function byggTabell(data, tabellId) {
       const table = document.getElementById(tabellId);
       table.innerHTML = "";
@@ -148,6 +158,28 @@
       sorted.forEach(row => tbody.appendChild(row));
     }
 
+    function filterByYear(data, year) {
+      return year === "alla" ? data : data.filter(r => r["Läsår"] === year);
+    }
+
+    function uppdateraTabeller() {
+      const year = document.getElementById("lasar-select").value;
+      byggTabell(filterByYear(dataOgiltig, year), "ogiltig");
+      byggTabell(filterByYear(dataTotal, year), "total");
+      byggTabell(filterByYear(dataMerit, year), "merit");
+    }
+
+    function uppdateraLasarDropdown() {
+      const select = document.getElementById("lasar-select");
+      select.innerHTML = "<option value=\"alla\">Alla</option>";
+      Array.from(lasarSet).sort().forEach(y => {
+        const opt = document.createElement("option");
+        opt.value = y;
+        opt.textContent = y;
+        select.appendChild(opt);
+      });
+    }
+
     function läggTillKort(titel, värde, klass = "") {
       const card = document.createElement("div");
       card.className = `card ${klass}`;
@@ -166,30 +198,40 @@
     }
 
     document.getElementById("filter").addEventListener("change", e => visaTabell(e.target.value));
+    document.getElementById("lasar-select").addEventListener("change", uppdateraTabeller);
     visaTabell("alla");
 
 
-    fetch("json/ogiltig_franvaro.json")
+    fetch(`json/${LASAR}/ogiltig_franvaro.json`)
       .then(r => r.json())
       .then(data => {
-        byggTabell(data, "ogiltig");
+        dataOgiltig = data;
+        data.forEach(r => lasarSet.add(r["Läsår"]));
+        uppdateraLasarDropdown();
+        uppdateraTabeller();
         const medel = data.reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / data.length;
         läggTillKort("Medel korrelation – Ogiltig", medel.toFixed(2));
       });
 
-    fetch("json/total_franvaro.json")
+    fetch(`json/${LASAR}/total_franvaro.json`)
       .then(r => r.json())
       .then(data => {
-        byggTabell(data, "total");
+        dataTotal = data;
+        data.forEach(r => lasarSet.add(r["Läsår"]));
+        uppdateraLasarDropdown();
+        uppdateraTabeller();
         const medel = data.reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / data.length;
         läggTillKort("Medel korrelation – Total", medel.toFixed(2));
       });
 
     Promise.all([
-      fetch("json/merit_ogiltig_franvaro.json").then(r => r.json()),
-      fetch("json/merit_total_franvaro.json").then(r => r.json())
+      fetch(`json/${LASAR}/merit_ogiltig_franvaro.json`).then(r => r.json()),
+      fetch(`json/${LASAR}/merit_total_franvaro.json`).then(r => r.json())
     ]).then(([ogiltig, total]) => {
-      byggTabell([ogiltig, total], "merit");
+      dataMerit = [ogiltig, total];
+      [ogiltig, total].forEach(r => lasarSet.add(r["Läsår"]));
+      uppdateraLasarDropdown();
+      uppdateraTabeller();
       const snitt = (parseFloat(ogiltig.Korrelation || 0) + parseFloat(total.Korrelation || 0)) / 2;
       läggTillKort("Medel korrelation – Meritvärde", snitt.toFixed(2));
     });

--- a/src/busavsjo_exportera_betyg_excel.py
+++ b/src/busavsjo_exportera_betyg_excel.py
@@ -1,5 +1,5 @@
 import openpyxl
-from config_paths import OUTPUT_DIR
+from config_paths import OUTPUT_DIR, LASAR
 
 # Definiera rubrikerna
 headers = [

--- a/src/busavsjo_korrelation_betyg_franvaro.py
+++ b/src/busavsjo_korrelation_betyg_franvaro.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from openpyxl.styles import PatternFill
 from openpyxl import load_workbook
-from config_paths import OUTPUT_DIR
+from config_paths import OUTPUT_DIR, LASAR
 
 # === INSTÄLLNINGAR ===
 DATA_MAPP = OUTPUT_DIR
@@ -120,6 +120,7 @@ samman_df.to_excel(OUTPUT_FIL, index=False)
 # === STEG 6 ===
 if korrelationer:
     resultat_df = pd.DataFrame(korrelationer)
+    resultat_df["Läsår"] = LASAR
     ogiltig_df = resultat_df[resultat_df["Frånvarotyp"] == "ogiltig_frånvaro_pct"]
     total_df = resultat_df[resultat_df["Frånvarotyp"] == "total_frånvaro"]
 
@@ -147,6 +148,7 @@ JSON_MAPP.mkdir(parents=True, exist_ok=True)
 def spara_json(df, filnamn):
     df_clean = df.copy()
     df_clean["Korrelation"] = df_clean["Korrelation"].apply(lambda x: round(x, 2) if pd.notna(x) else None)
+    df_clean["Läsår"] = LASAR
     df_clean = df_clean.where(pd.notna(df_clean), None)
     with (JSON_MAPP / filnamn).open("w", encoding="utf-8") as f:
         json.dump(df_clean.to_dict(orient="records"), f, indent=2, ensure_ascii=False)
@@ -179,6 +181,7 @@ for kol in ["ogiltig_frånvaro_pct", "total_frånvaro"]:
 # === STEG 9 ===
 if korrelation_merit:
     merit_df = pd.DataFrame(korrelation_merit)
+    merit_df["Läsår"] = LASAR
     with pd.ExcelWriter(RESULTAT_FIL, engine='openpyxl', mode='a') as writer:
         merit_df.to_excel(writer, index=False, sheet_name="Meritvärde vs frånvaro")
 
@@ -196,6 +199,7 @@ if korrelation_merit:
     wb.save(RESULTAT_FIL)
 
     for rad in korrelation_merit:
+        rad["Läsår"] = LASAR
         filnamn = "merit_" + ("ogiltig" if "ogiltig" in rad["Typ"] else "total") + "_franvaro.json"
         with (JSON_MAPP / filnamn).open("w", encoding="utf-8") as f:
             json.dump(rad, f, indent=2, ensure_ascii=False)

--- a/src/busavsjo_rensa_franvaro_excel.py
+++ b/src/busavsjo_rensa_franvaro_excel.py
@@ -3,7 +3,7 @@ from openpyxl import Workbook
 from openpyxl.styles import PatternFill, Alignment, Font, Border, Side
 from openpyxl.utils.dataframe import dataframe_to_rows
 import re
-from config_paths import OUTPUT_DIR
+from config_paths import OUTPUT_DIR, LASAR
 DATA_MAPP = OUTPUT_DIR
 FIL_IN = DATA_MAPP / "franvaro.xls"
 FIL_UT = DATA_MAPP / "franvaro_rensad_kategoriserad.xlsx"

--- a/src/busavsjo_samla_betygstxt.py
+++ b/src/busavsjo_samla_betygstxt.py
@@ -1,8 +1,8 @@
-from config_paths import RAW_BETYG_DIR, OUTPUT_DIR
+from config_paths import RAW_BETYG_DIR, OUTPUT_DIR, LASAR
 
 def busavsjo_samla_txtfiler():
-    """Läser in alla .txt-filer i ``data/raw/betyg`` och
-    sparar ihop dem till ``data/output/betyg.txt``"""
+    """Läser in alla .txt-filer för läsåret i ``data/raw/betyg/<läsår>`` och
+    sparar ihop dem till ``data/output/<läsår>/betyg.txt``"""
     indata_mapp = RAW_BETYG_DIR
     utdata_fil = OUTPUT_DIR / "betyg.txt"
     med_antal = 0

--- a/src/busavsjo_samla_franvaro.py
+++ b/src/busavsjo_samla_franvaro.py
@@ -1,11 +1,12 @@
 import xlrd
 import xlwt
-from config_paths import RAW_FRANVARO_DIR, OUTPUT_DIR
+from config_paths import RAW_FRANVARO_DIR, OUTPUT_DIR, LASAR
 
 
 def busavsjo_samla_franvarorapporter():
     """
-    Slår ihop alla .xls-filer i ``data/raw/franvaro`` till en fil (``data/output/franvaro.xls``),
+    Slår ihop alla .xls-filer i ``data/raw/franvaro/<läsår>`` till en fil
+    (``data/output/<läsår>/franvaro.xls``),
     behåller bara rubriken från första filen och hoppar över de fyra första raderna i resten.
     """
     indata_mapp = RAW_FRANVARO_DIR

--- a/src/config_paths.py
+++ b/src/config_paths.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Läsåret som analyseras
+LASAR = "2024/2025"
+
 RAW_DIR = BASE_DIR / "data" / "raw"
-RAW_BETYG_DIR = RAW_DIR / "betyg"
-RAW_FRANVARO_DIR = RAW_DIR / "franvaro"
-OUTPUT_DIR = BASE_DIR / "data" / "output"
+RAW_BETYG_DIR = RAW_DIR / "betyg" / LASAR
+RAW_FRANVARO_DIR = RAW_DIR / "franvaro" / LASAR
+OUTPUT_DIR = BASE_DIR / "data" / "output" / LASAR


### PR DESCRIPTION
## Summary
- introduce `LASAR` constant in `config_paths`
- include the year in all data paths
- add school year dropdown and filtering in the UI
- persist the school year in correlation results and JSON
- document year configuration and output folders in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688ce0dc8ca88328b905c4ac1e67708a