### PR TITLE
Add configurable subject display names for results

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ De JSON-filer som genereras för webbgränssnittet hamnar i
 `data/output/<läsår>/json/`. Kopiera dem vid behov till motsvarande mapp under
 `public/json/<läsår>` för att exponera dem via webbplatsen.
 
+### Konfiguration av ämnesnamn
+
+För att kunna visa mer lättförståeliga namn för skolämnen i
+resultat- och JSON-filer finns filen `config/subject_names.json`. Här kan
+varje ämneskolumn från betygsfilen kopplas till ett visningsnamn.
+Om en kolumn saknas i filen används kolumnens originalnamn.
+
 Kör hela flödet med:
 
 ```bash

--- a/config/subject_names.json
+++ b/config/subject_names.json
@@ -1,0 +1,19 @@
+{
+  "En": "Engelska",
+  "Ma": "Matematik",
+  "Sv": "Svenska",
+  "Sva": "Svenska som andraspråk",
+  "No": "Naturorienterande ämnen",
+  "So": "Samhällsorienterande ämnen",
+  "Bi": "Biologi",
+  "Fy": "Fysik",
+  "Ke": "Kemi",
+  "Ge": "Geografi",
+  "Hi": "Historia",
+  "Re": "Religionskunskap",
+  "Sh": "Samhällskunskap",
+  "Hkk": "Hem- och konsumentkunskap",
+  "idh": "Idrott och hälsa",
+  "mu": "Musik",
+  "Tk": "Teknik"
+}

--- a/src/busavsjo_korrelation_betyg_franvaro.py
+++ b/src/busavsjo_korrelation_betyg_franvaro.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from openpyxl.styles import PatternFill
 from openpyxl import load_workbook
-from config_paths import OUTPUT_DIR, LASAR
+from config_paths import OUTPUT_DIR, LASAR, CONFIG_DIR
 
 # === INSTÄLLNINGAR ===
 DATA_MAPP = OUTPUT_DIR
@@ -14,6 +14,13 @@ BETYG_FIL = DATA_MAPP / "betyg.xlsx"
 OUTPUT_FIL = DATA_MAPP / "busavsjo_korrelation_input.xlsx"
 RESULTAT_FIL = DATA_MAPP / "busavsjo_korrelation_resultat.xlsx"
 JSON_MAPP = DATA_MAPP / "json"
+
+AMNEN_KONFIG = CONFIG_DIR / "subject_names.json"
+try:
+    with AMNEN_KONFIG.open("r", encoding="utf-8") as f:
+        AMNEN_DISPLAY = json.load(f)
+except FileNotFoundError:
+    AMNEN_DISPLAY = {}
 
 IGNORERA_KOLUMNER = {
     "System", "Datum", "Version", "Skolenhetskod",
@@ -108,8 +115,10 @@ for betyg in [f"{amne}_num" for amne in BETYGSKOLUMNER]:
             if x.notna().sum() >= 2 and y.notna().sum() >= 2:
                 corr = x.corr(y)
                 if pd.notna(corr):
+                    amne_kod = betyg.replace("_num", "")
+                    visningsnamn = AMNEN_DISPLAY.get(amne_kod, amne_kod)
                     korrelationer.append({
-                        "Ämne": betyg.replace("_num", ""),
+                        "Ämne": visningsnamn,
                         "Frånvarotyp": kol,
                         "Korrelation": round(corr, 2),
                         "Styrka": tolka_korrelation(corr)

--- a/src/config_paths.py
+++ b/src/config_paths.py
@@ -9,3 +9,4 @@ RAW_DIR = BASE_DIR / "data" / "raw"
 RAW_BETYG_DIR = RAW_DIR / "betyg" / LASAR
 RAW_FRANVARO_DIR = RAW_DIR / "franvaro" / LASAR
 OUTPUT_DIR = BASE_DIR / "data" / "output" / LASAR
+CONFIG_DIR = BASE_DIR / "config"


### PR DESCRIPTION
## Summary
- add subject display name mapping via `config/subject_names.json`
- load subject name config in correlation script and use display names in outputs
- document subject name configuration in README

## Testing
- `python -m py_compile src/config_paths.py src/busavsjo_korrelation_betyg_franvaro.py`


------
https://chatgpt.com/codex/tasks/task_b_6890754cc8ac83288c89aca842d44be6