### PR TITLE
Handle missing JSON files gracefully

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -212,22 +212,43 @@ async function läsJsonData() {
     "total_franvaro_pct_ak6.json",
     "total_franvaro_pct_ak9.json"
   ];
-  const jsondata = await Promise.all(
-    filer.map(fil => fetch(`${JSON_PATH}/${fil}`).then(r => r.json()))
-  );
-  dataOgiltig = jsondata[0].concat(jsondata[1]);
-  dataTotal = jsondata[2].concat(jsondata[3]);
-  dataMerit = []; // Lägg till om meritdata finns
+  try {
+    const jsondata = await Promise.all(
+      filer.map(async fil => {
+        try {
+          const response = await fetch(`${JSON_PATH}/${fil}`);
+          if (!response.ok) {
+            const msg = `Kunde inte ladda ${fil}`;
+            console.error(msg);
+            läggTillKort(msg, "", "negativ");
+            return [];
+          }
+          return await response.json();
+        } catch (err) {
+          const msg = `Fel vid hämtning av ${fil}`;
+          console.error(msg, err);
+          läggTillKort(msg, "", "negativ");
+          return [];
+        }
+      })
+    );
+    dataOgiltig = jsondata[0].concat(jsondata[1]);
+    dataTotal = jsondata[2].concat(jsondata[3]);
+    dataMerit = []; // Lägg till om meritdata finns
 
-  [...dataOgiltig, ...dataTotal].forEach(r => lasarSet.add(r["Läsår"]));
-  uppdateraLasarDropdown();
-  uppdateraTabeller();
+    [...dataOgiltig, ...dataTotal].forEach(r => lasarSet.add(r["Läsår"]));
+    uppdateraLasarDropdown();
+    uppdateraTabeller();
 
-  const snittOgiltig = dataOgiltig.reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / dataOgiltig.length;
-  const snittTotal = dataTotal.reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / dataTotal.length;
+    const snittOgiltig = dataOgiltig.length ? dataOgiltig.reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / dataOgiltig.length : 0;
+    const snittTotal = dataTotal.length ? dataTotal.reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / dataTotal.length : 0;
 
-  läggTillKort("Medel korrelation – Ogiltig", snittOgiltig.toFixed(2));
-  läggTillKort("Medel korrelation – Total", snittTotal.toFixed(2));
+    läggTillKort("Medel korrelation – Ogiltig", dataOgiltig.length ? snittOgiltig.toFixed(2) : "N/A");
+    läggTillKort("Medel korrelation – Total", dataTotal.length ? snittTotal.toFixed(2) : "N/A");
+  } catch (error) {
+    console.error("Fel vid läsning av JSON-data:", error);
+    läggTillKort("Fel", "Kunde inte ladda data", "negativ");
+  }
 }
 
 visaTabell("alla");


### PR DESCRIPTION
## Summary
- guard `läsJsonData` fetching with try/catch
- log and surface per-file fetch failures while continuing to render
- avoid NaN averages when data is missing

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6890b58c7b2483288e80e6e796a2825e