### PR TITLE
Fix NaN handling in correlation JSON export

### DIFF
--- a/src/busavsjo_korrelation_betyg_franvaro.py
+++ b/src/busavsjo_korrelation_betyg_franvaro.py
@@ -21,10 +21,10 @@ def spara_json(df, filnamn, årskurs):
     df_clean = df.copy()
 
     # Runda korrelationer endast om de är giltiga
-   df_clean["Korrelation"] = df_clean["Korrelation"].apply(
-    lambda x: round(float(x), 2) if isinstance(x, (int, float, np.floating)) and not np.isnan(x) else None
-)
-
+    df_clean["Korrelation"] = df_clean["Korrelation"].apply(
+        lambda x: round(float(x), 2)
+        if isinstance(x, (int, float, np.floating)) and not np.isnan(x)
+        else None
     )
 
     # Ersätt eventuella kvarvarande NaN med None
@@ -40,7 +40,8 @@ def spara_json(df, filnamn, årskurs):
             f,
             indent=2,
             ensure_ascii=False,
-            default=lambda x: None  # Hantera t.ex. np.float32 och NaN
+            default=lambda x: None,  # Hantera t.ex. np.float32 och NaN
+            allow_nan=False,
         )
 
 def analysera_korrelation(klass_varde, betyg_df):


### PR DESCRIPTION
## Summary
- Round valid correlation values and replace remaining NaNs with None before saving
- Disallow NaN values when dumping to JSON

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6890d5f69b7c8328bde652d8ab9c79d0