### PR TITLE
Add merit average dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -216,7 +216,8 @@ async function läsJsonData() {
     "total_franvaro_pct_ak6.json",
     "total_franvaro_pct_ak9.json",
     "meritvarde_ak6.json",
-    "meritvarde_ak9.json"
+    "meritvarde_ak9.json",
+    "medel_meritvarde.json"
   ];
   try {
     const jsondata = await Promise.all(
@@ -241,6 +242,7 @@ async function läsJsonData() {
     dataOgiltig = jsondata[0].concat(jsondata[1]);
     dataTotal = jsondata[2].concat(jsondata[3]);
     dataMerit = jsondata[4].concat(jsondata[5]);
+    const medelMerit = jsondata[6] || [];
 
     [...dataOgiltig, ...dataTotal, ...dataMerit].forEach(r => lasarSet.add(r["Läsår"]));
     uppdateraLasarDropdown();
@@ -255,18 +257,13 @@ async function läsJsonData() {
     const snittMerit = dataMerit.length
       ? dataMerit.reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / dataMerit.length
       : 0;
-    const snittMeritAk6 = jsondata[4].length
-      ? jsondata[4].reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / jsondata[4].length
-      : 0;
-    const snittMeritAk9 = jsondata[5].length
-      ? jsondata[5].reduce((acc, r) => acc + parseFloat(r.Korrelation || 0), 0) / jsondata[5].length
-      : 0;
-
     läggTillKort("Medel korrelation – Ogiltig", dataOgiltig.length ? snittOgiltig.toFixed(2) : "N/A");
     läggTillKort("Medel korrelation – Total", dataTotal.length ? snittTotal.toFixed(2) : "N/A");
     läggTillKort("Medel korrelation – Meritvärde", dataMerit.length ? snittMerit.toFixed(2) : "N/A");
-    läggTillKort("Åk 6 – Meritvärde", jsondata[4].length ? snittMeritAk6.toFixed(2) : "N/A");
-    läggTillKort("Åk 9 – Meritvärde", jsondata[5].length ? snittMeritAk9.toFixed(2) : "N/A");
+    medelMerit.forEach(r => {
+      const titel = `Åk ${r["Årskurs"]} – Medel meritvärde`;
+      läggTillKort(titel, r["MedelMeritvärde"].toFixed(2));
+    });
   } catch (error) {
     console.error("Fel vid läsning av JSON-data:", error);
     läggTillKort("Fel", "Kunde inte ladda data", "negativ");

--- a/public/json/2024-2025/medel_meritvarde.json
+++ b/public/json/2024-2025/medel_meritvarde.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Årskurs": 6,
+    "MedelMeritvärde": 206.67
+  },
+  {
+    "Årskurs": 9,
+    "MedelMeritvärde": 240.0
+  }
+]

--- a/src/busavsjo_medel_merit.py
+++ b/src/busavsjo_medel_merit.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import json
+import pandas as pd
+from config_paths import RAW_BETYG_DIR, LASAR, BASE_DIR
+
+def berakna_medel_merit():
+    filer = [
+        ("betyg_ak6_med_merit.xlsx", 6),
+        ("betyg_ak9_med_merit.xlsx", 9),
+    ]
+    resultat = []
+    for filnamn, arskurs in filer:
+        fil = RAW_BETYG_DIR / filnamn
+        if not fil.exists():
+            print(f"⚠️ Filen '{fil}' saknas – hoppar över.")
+            continue
+        df = pd.read_excel(fil)
+        kolumn = next((c for c in df.columns if "merit" in c.lower()), None)
+        if kolumn is None:
+            print(f"⚠️ Ingen meritvärde-kolumn i '{fil}'.")
+            continue
+        medel = pd.to_numeric(df[kolumn], errors="coerce").mean()
+        resultat.append({"Årskurs": arskurs, "MedelMeritvärde": round(float(medel), 2)})
+
+    if not resultat:
+        print("⚠️ Ingen data att spara.")
+        return
+
+    out_dir = BASE_DIR / "public" / "json" / LASAR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_fil = out_dir / "medel_meritvarde.json"
+    with out_fil.open("w", encoding="utf-8") as f:
+        json.dump(resultat, f, ensure_ascii=False, indent=2)
+    print(f"✅ Sparade medel meritvärde i '{out_fil}'.")
+
+if __name__ == "__main__":
+    berakna_medel_merit()


### PR DESCRIPTION
## Summary
- Compute mean merit values for årskurs 6 and 9 from Excel files
- Display calculated averages in dashboard on index.html

## Testing
- `pytest -q`
- `python src/busavsjo_medel_merit.py`


------
https://chatgpt.com/codex/tasks/task_b_6891087e36888328b7f34f8e232771ca