### PR TITLE
Add merit calculation step to pipeline and document data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Detta projekt är strukturerat enligt Sävsjö kommuns riktlinjer.
 
 Projektet använder en **raw/output**-struktur under `data/`:
 
-- `data/raw/betyg/` – här läggs SCB-exporterade txt-filer från Edlevo.
-- `data/raw/franvaro/` – här läggs frånvarofiler (`.xls`) från Vklass.
-- `data/output/` – hit skrivs samtliga genererade filer.
+- `data/raw/betyg/<läsår>/ak6` och `data/raw/betyg/<läsår>/ak9` –
+  här läggs SCB-exporterade betygs‑txt‑filer från Edlevo för respektive årskurs.
+- `data/raw/franvaro/<läsår>` – här placeras frånvarofiler (`.xls`) från Vklass.
+- `data/output/<läsår>` – hit skrivs samtliga genererade Excel‑ och textfiler.
+- `data/output/json/<läsår>` – här hamnar de JSON‑filer som webbgränssnittet använder.
 
 ### Läsår och mappar
 
@@ -21,8 +23,15 @@ undermappar med detta namn, t.ex. `data/raw/betyg/<läsår>` och
 `data/output/<läsår>`. På så vis kan flera års data hanteras utan konflikt.
 
 De JSON-filer som genereras för webbgränssnittet hamnar i
-`data/output/<läsår>/json/`. Kopiera dem vid behov till motsvarande mapp under
+`data/output/json/<läsår>`. Kopiera dem vid behov till motsvarande mapp under
 `public/json/<läsår>` för att exponera dem via webbplatsen.
+
+### Outputfiler
+
+Efter en lyckad körning ligger sammanställda Excel‑filer och
+resultat i `data/output/<läsår>` (t.ex. `betyg_ak6.xlsx`,
+`franvaro_total.xlsx`, `betyg_ak6_med_merit.xlsx`).
+JSON‑exporter sparas i `data/output/json/<läsår>`.
 
 ### Konfiguration av ämnesnamn
 

--- a/src/busavsjo_pipeline.py
+++ b/src/busavsjo_pipeline.py
@@ -7,6 +7,7 @@ Steg i rätt ordning:
 4. Rensa och kategorisera frånvaro
 5. Skapa sammanställning `franvaro_total.xlsx`
 6. Kör korrelationsanalys mellan betyg och frånvaro
+7. Beräkna medelmeritvärde
 """
 
 import importlib.util
@@ -24,6 +25,7 @@ MODULER = [
     "busavsjo_rensa_franvaro_excel",  # 4
     "busavsjo_skapa_franvaro_total",  # 5 – NYTT steg som skapar franvaro_total.xlsx
     "busavsjo_korrelation_betyg_franvaro",  # 6
+    "busavsjo_medel_merit",                 # 7
 ]
 
 


### PR DESCRIPTION
## Summary
- Extend pipeline with a final module to compute mean merit values
- Clarify README with exact raw-data locations and where outputs are stored

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6891d9f5b95c8328b807b1635692203f